### PR TITLE
feat: require kwargs in all model methods with paremeters

### DIFF
--- a/src/aiortm/model/contacts.py
+++ b/src/aiortm/model/contacts.py
@@ -59,7 +59,7 @@ class Contacts:
 
     api: Auth
 
-    async def add(self, timeline: int, contact: str) -> ContactAddResponse:
+    async def add(self, *, timeline: int, contact: str) -> ContactAddResponse:
         """Add a contact."""
         result = await self.api.call_api_auth(
             "rtm.contacts.add",
@@ -68,7 +68,7 @@ class Contacts:
         )
         return ContactAddResponse.from_dict(result)
 
-    async def delete(self, timeline: int, contact_id: int) -> ContactDeleteResponse:
+    async def delete(self, *, timeline: int, contact_id: int) -> ContactDeleteResponse:
         """Delete a contact."""
         result = await self.api.call_api_auth(
             "rtm.contacts.delete",

--- a/src/aiortm/model/tasks.py
+++ b/src/aiortm/model/tasks.py
@@ -122,6 +122,7 @@ class Tasks:
 
     async def add(
         self,
+        *,
         timeline: int,
         name: str,
         list_id: int | None = None,
@@ -139,6 +140,7 @@ class Tasks:
 
     async def complete(
         self,
+        *,
         timeline: int,
         list_id: int,
         taskseries_id: int,
@@ -156,6 +158,7 @@ class Tasks:
 
     async def delete(
         self,
+        *,
         timeline: int,
         list_id: int,
         taskseries_id: int,
@@ -173,6 +176,7 @@ class Tasks:
 
     async def get_list(
         self,
+        *,
         list_id: int | None = None,
         last_sync: datetime | None = None,
     ) -> TasksResponse:
@@ -190,6 +194,7 @@ class Tasks:
 
     async def set_name(
         self,
+        *,
         timeline: int,
         list_id: int,
         taskseries_id: int,


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiortm/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
BREAKING CHANGE: All model methods that have parameters now require kwargs.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiortm/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
