### PR TITLE
feat: add tasks.uncomplete method

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,2 @@
 [codespell]
-ignore-words-list = socio-economic
+ignore-words-list = socio-economic,uncomplete

--- a/src/aiortm/model/tasks.py
+++ b/src/aiortm/model/tasks.py
@@ -156,6 +156,24 @@ class Tasks:
         )
         return TaskModifiedResponse.from_dict(result)
 
+    async def uncomplete(
+        self,
+        *,
+        timeline: int,
+        list_id: int,
+        taskseries_id: int,
+        task_id: int,
+    ) -> TaskModifiedResponse:
+        """Uncomplete a task."""
+        result = await self.api.call_api_auth(
+            "rtm.tasks.uncomplete",
+            timeline=timeline,
+            list_id=list_id,
+            taskseries_id=taskseries_id,
+            task_id=task_id,
+        )
+        return TaskModifiedResponse.from_dict(result)
+
     async def delete(
         self,
         *,

--- a/tests/fixtures/tasks/uncomplete.json
+++ b/tests/fixtures/tasks/uncomplete.json
@@ -1,0 +1,36 @@
+{
+  "rsp": {
+    "stat": "ok",
+    "transaction": { "id": "12475899885", "undoable": "1" },
+    "list": {
+      "id": "48730705",
+      "taskseries": [
+        {
+          "id": "493137362",
+          "created": "2023-01-02T01:55:25Z",
+          "modified": "2023-01-05T01:00:00Z",
+          "name": "Test task",
+          "source": "api:test-api-key",
+          "url": "",
+          "location_id": "",
+          "tags": [],
+          "participants": [],
+          "notes": [],
+          "task": [
+            {
+              "id": "924832826",
+              "due": "",
+              "has_due_time": "0",
+              "added": "2023-01-02T01:55:25Z",
+              "completed": "",
+              "deleted": "",
+              "priority": "N",
+              "postponed": "0",
+              "estimate": ""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/model/test_tasks.py
+++ b/tests/model/test_tasks.py
@@ -82,26 +82,36 @@ async def test_tasks_add(
 
 
 @pytest.mark.parametrize(
-    ("method", "transaction", "modified", "deleted", "response"),
+    ("method", "transaction", "modified", "completed", "deleted", "response"),
     [
         (
             "complete",
             12475899884,
             datetime.fromisoformat("2023-01-05T00:04:52+00:00"),
+            datetime.fromisoformat("2023-01-05T00:04:52+00:00"),
             None,
             "tasks/complete.json",
+        ),
+        (
+            "uncomplete",
+            12475899885,
+            datetime.fromisoformat("2023-01-05T01:00:00+00:00"),
+            None,
+            None,
+            "tasks/uncomplete.json",
         ),
         (
             "delete",
             12476056249,
             datetime.fromisoformat("2023-01-05T00:34:45+00:00"),
+            datetime.fromisoformat("2023-01-05T00:04:52+00:00"),
             datetime.fromisoformat("2023-01-05T00:34:45+00:00"),
             "tasks/delete.json",
         ),
     ],
     indirect=["response"],
 )
-async def test_tasks_complete_delete(
+async def test_tasks_complete_uncomplete_delete(
     client: AioRTMClient,
     mock_response: aiointercept,
     timelines_create: str,
@@ -109,10 +119,11 @@ async def test_tasks_complete_delete(
     method: str,
     transaction: int,
     modified: datetime,
+    completed: datetime | None,
     deleted: datetime | None,
     response: str,
 ) -> None:
-    """Test tasks complete and delete."""
+    """Test tasks complete, uncomplete and delete."""
     mock_response.get(
         generate_url(
             api_key="test-api-key",
@@ -156,9 +167,7 @@ async def test_tasks_complete_delete(
     assert result.task_list.taskseries[0].name == "Test task"
     assert result.task_list.taskseries[0].source == "api:test-api-key"
     assert result.task_list.taskseries[0].task[0].id == 924832826
-    assert result.task_list.taskseries[0].task[0].completed == datetime.fromisoformat(
-        "2023-01-05T00:04:52+00:00",
-    )
+    assert result.task_list.taskseries[0].task[0].completed == completed
     assert result.task_list.taskseries[0].task[0].deleted == deleted
 
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiortm/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Adds rtm.tasks.uncomplete to toggle a completed task back to needs_action, mirroring the existing complete method signature.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiortm/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
