### PR TITLE
feat: add tasks.set_due_date method

### DIFF
--- a/src/aiortm/model/tasks.py
+++ b/src/aiortm/model/tasks.py
@@ -192,6 +192,40 @@ class Tasks:
         )
         return TaskModifiedResponse.from_dict(result)
 
+    async def set_due_date(
+        self,
+        *,
+        timeline: int,
+        list_id: int,
+        taskseries_id: int,
+        task_id: int,
+        due: datetime | str | None = None,
+        has_due_time: bool | None = None,
+        parse: bool | None = None,
+    ) -> TaskModifiedResponse:
+        """Set or clear the due date of a task.
+
+        Pass a datetime or ISO-8601 string for *due* to set a due date.
+        Omit *due* (leave as None) to clear it.
+        Set *parse* to True to let RTM interpret a natural-language string.
+        """
+        due_string: str | None = None
+        if isinstance(due, datetime):
+            due_string = due.isoformat()
+        elif isinstance(due, str):
+            due_string = due
+        result = await self.api.call_api_auth(
+            "rtm.tasks.setDueDate",
+            timeline=timeline,
+            list_id=list_id,
+            taskseries_id=taskseries_id,
+            task_id=task_id,
+            due=due_string,
+            has_due_time="1" if has_due_time else None,
+            parse="1" if parse else None,
+        )
+        return TaskModifiedResponse.from_dict(result)
+
     async def get_list(
         self,
         *,

--- a/tests/fixtures/tasks/set_due_date.json
+++ b/tests/fixtures/tasks/set_due_date.json
@@ -1,0 +1,36 @@
+{
+  "rsp": {
+    "stat": "ok",
+    "transaction": { "id": "12500000001", "undoable": "1" },
+    "list": {
+      "id": "48730705",
+      "taskseries": [
+        {
+          "id": "493137362",
+          "created": "2023-01-02T01:55:25Z",
+          "modified": "2023-01-06T10:00:00Z",
+          "name": "Test task",
+          "source": "api:test-api-key",
+          "url": "",
+          "location_id": "",
+          "tags": [],
+          "participants": [],
+          "notes": [],
+          "task": [
+            {
+              "id": "924832826",
+              "due": "2023-01-10T14:00:00Z",
+              "has_due_time": "1",
+              "added": "2023-01-02T01:55:25Z",
+              "completed": "",
+              "deleted": "",
+              "priority": "N",
+              "postponed": "0",
+              "estimate": ""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/tasks/set_due_date_clear.json
+++ b/tests/fixtures/tasks/set_due_date_clear.json
@@ -1,0 +1,36 @@
+{
+  "rsp": {
+    "stat": "ok",
+    "transaction": { "id": "12500000002", "undoable": "1" },
+    "list": {
+      "id": "48730705",
+      "taskseries": [
+        {
+          "id": "493137362",
+          "created": "2023-01-02T01:55:25Z",
+          "modified": "2023-01-06T11:00:00Z",
+          "name": "Test task",
+          "source": "api:test-api-key",
+          "url": "",
+          "location_id": "",
+          "tags": [],
+          "participants": [],
+          "notes": [],
+          "task": [
+            {
+              "id": "924832826",
+              "due": "",
+              "has_due_time": "0",
+              "added": "2023-01-02T01:55:25Z",
+              "completed": "",
+              "deleted": "",
+              "priority": "N",
+              "postponed": "0",
+              "estimate": ""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/model/test_tasks.py
+++ b/tests/model/test_tasks.py
@@ -306,6 +306,19 @@ async def test_tasks_set_name(
             12500000001,
         ),
         (
+            "tasks/set_due_date.json",
+            {
+                "due": "2023-01-10T14:00:00+00:00",
+                "has_due_time": "1",
+            },
+            {
+                "due": "2023-01-10T14:00:00+00:00",
+                "has_due_time": True,
+            },
+            datetime.fromisoformat("2023-01-10T14:00:00+00:00"),
+            12500000001,
+        ),
+        (
             "tasks/set_due_date_clear.json",
             {},
             {},

--- a/tests/model/test_tasks.py
+++ b/tests/model/test_tasks.py
@@ -287,3 +287,82 @@ async def test_tasks_set_name(
     assert result.task_list.taskseries[0].task[0].added == datetime.fromisoformat(
         "2023-01-05T01:39:14+00:00",
     )
+
+
+@pytest.mark.parametrize(
+    ("response", "response_params", "method_params", "due", "transaction"),
+    [
+        (
+            "tasks/set_due_date.json",
+            {
+                "due": "2023-01-10T14:00:00+00:00",
+                "has_due_time": "1",
+            },
+            {
+                "due": datetime.fromisoformat("2023-01-10T14:00:00+00:00"),
+                "has_due_time": True,
+            },
+            datetime.fromisoformat("2023-01-10T14:00:00+00:00"),
+            12500000001,
+        ),
+        (
+            "tasks/set_due_date_clear.json",
+            {},
+            {},
+            None,
+            12500000002,
+        ),
+    ],
+    indirect=["response"],
+)
+async def test_tasks_set_due_date(
+    client: AioRTMClient,
+    mock_response: aiointercept,
+    timelines_create: str,
+    generate_url: Callable[..., str],
+    response: str,
+    response_params: dict[str, Any],
+    method_params: dict[str, Any],
+    due: datetime | None,
+    transaction: int,
+) -> None:
+    """Test tasks set due date."""
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.timelines.create",
+        ),
+        body=timelines_create,
+    )
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.tasks.setDueDate",
+            timeline=1234567890,
+            list_id=48730705,
+            taskseries_id=493137362,
+            task_id=924832826,
+            **response_params,
+        ),
+        body=response,
+    )
+
+    timeline_response = await client.rtm.timelines.create()
+    timeline = timeline_response.timeline
+    result = await client.rtm.tasks.set_due_date(
+        timeline=timeline,
+        list_id=48730705,
+        taskseries_id=493137362,
+        task_id=924832826,
+        **method_params,
+    )
+
+    assert result.stat == "ok"
+    assert result.transaction.id == transaction
+    assert result.transaction.undoable == 1
+    assert result.task_list.id == 48730705
+    assert result.task_list.taskseries[0].id == 493137362
+    assert result.task_list.taskseries[0].task[0].id == 924832826
+    assert result.task_list.taskseries[0].task[0].due == due


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiortm/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Adds rtm.tasks.setDueDate to set or clear a task's due date. Accepts
a datetime object, an ISO-8601/natural-language string (with parse=True),
or None to clear the due date entirely.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiortm/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
