### PR TITLE
feat: add tasks.notes sub-model and fix notes read model

### DIFF
--- a/src/aiortm/model/tasks.py
+++ b/src/aiortm/model/tasks.py
@@ -33,6 +33,17 @@ class BaseModel(DataClassJSONMixin):
 
 
 @dataclass
+class NoteResponse(BaseModel):
+    """Represent a response for a note."""
+
+    id: int
+    created: datetime = field(metadata={"deserialize": "ciso8601"})
+    modified: datetime = field(metadata={"deserialize": "ciso8601"})
+    title: str | None = None
+    body: str | None = field(metadata=field_options(alias="$t"), default=None)
+
+
+@dataclass
 class TaskResponse(BaseModel):
     """Represent a response for a task."""
 
@@ -64,10 +75,21 @@ class TaskSeriesResponse(BaseModel):
     source: str
     tags: list[str]
     participants: list[str]
-    notes: list[str]
+    notes: list[NoteResponse]
     task: list[TaskResponse]
     location_id: str | None = None
     url: str | None = None
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
+        """Normalise notes from RTM's dict form to a list."""
+        notes = d.get("notes")
+        if isinstance(notes, dict):
+            d["notes"] = notes.get("note", [])
+            if isinstance(d["notes"], dict):
+                # Single note returned as a dict rather than a one-item list.
+                d["notes"] = [d["notes"]]
+        return super().__pre_deserialize__(d)
 
 
 @dataclass
@@ -100,6 +122,21 @@ class RootTaskResponse(BaseModel):
 
 
 @dataclass
+class NoteModifiedResponse(BaseResponse):
+    """Represent a response for an added or edited note."""
+
+    transaction: TransactionResponse
+    note: NoteResponse
+
+
+@dataclass
+class NoteDeleteResponse(BaseResponse):
+    """Represent a response for a deleted note."""
+
+    transaction: TransactionResponse
+
+
+@dataclass
 class TaskModifiedResponse(BaseResponse):
     """Represent a response for a modified task."""
 
@@ -115,10 +152,76 @@ class TasksResponse(BaseResponse):
 
 
 @dataclass
+class Notes:
+    """Represent the task notes model."""
+
+    api: Auth
+
+    async def add(
+        self,
+        *,
+        timeline: int,
+        list_id: int,
+        taskseries_id: int,
+        task_id: int,
+        title: str,
+        text: str,
+    ) -> NoteModifiedResponse:
+        """Add a note to a task."""
+        result = await self.api.call_api_auth(
+            "rtm.tasks.notes.add",
+            timeline=timeline,
+            list_id=list_id,
+            taskseries_id=taskseries_id,
+            task_id=task_id,
+            note_title=title,
+            note_text=text,
+        )
+        return NoteModifiedResponse.from_dict(result)
+
+    async def edit(
+        self,
+        *,
+        timeline: int,
+        note_id: int,
+        title: str,
+        text: str,
+    ) -> NoteModifiedResponse:
+        """Edit a note."""
+        result = await self.api.call_api_auth(
+            "rtm.tasks.notes.edit",
+            timeline=timeline,
+            note_id=note_id,
+            note_title=title,
+            note_text=text,
+        )
+        return NoteModifiedResponse.from_dict(result)
+
+    async def delete(
+        self,
+        *,
+        timeline: int,
+        note_id: int,
+    ) -> NoteDeleteResponse:
+        """Delete a note."""
+        result = await self.api.call_api_auth(
+            "rtm.tasks.notes.delete",
+            timeline=timeline,
+            note_id=note_id,
+        )
+        return NoteDeleteResponse.from_dict(result)
+
+
+@dataclass
 class Tasks:
     """Represent the tasks model."""
 
     api: Auth
+    notes: Notes = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Set up the instance."""
+        self.notes = Notes(self.api)
 
     async def add(
         self,

--- a/tests/fixtures/tasks/get_list_with_notes.json
+++ b/tests/fixtures/tasks/get_list_with_notes.json
@@ -1,0 +1,57 @@
+{
+  "rsp": {
+    "stat": "ok",
+    "tasks": {
+      "rev": "do4bcfiw180e4zo6c528eqm2auwpmmu",
+      "list": [
+        {
+          "id": "48730707",
+          "taskseries": [
+            {
+              "id": "617871865",
+              "created": "2026-08-06T16:24:16Z",
+              "modified": "2026-08-06T19:18:14Z",
+              "name": "Test 1",
+              "source": "js",
+              "url": "",
+              "location_id": "",
+              "tags": [],
+              "participants": [],
+              "notes": {
+                "note": [
+                  {
+                    "id": "118703500",
+                    "created": "2026-08-06T19:18:14Z",
+                    "modified": "2026-08-06T19:18:14Z",
+                    "title": "",
+                    "$t": "Note 2."
+                  },
+                  {
+                    "id": "118701722",
+                    "created": "2026-08-06T16:24:45Z",
+                    "modified": "2026-08-06T16:24:45Z",
+                    "title": "",
+                    "$t": "Note 1."
+                  }
+                ]
+              },
+              "task": [
+                {
+                  "id": "1221265356",
+                  "due": "",
+                  "has_due_time": "0",
+                  "added": "2026-08-06T16:24:16Z",
+                  "completed": "",
+                  "deleted": "",
+                  "priority": "N",
+                  "postponed": "0",
+                  "estimate": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/tasks/notes/add.json
+++ b/tests/fixtures/tasks/notes/add.json
@@ -1,0 +1,13 @@
+{
+  "rsp": {
+    "stat": "ok",
+    "transaction": { "id": "12600000001", "undoable": "1" },
+    "note": {
+      "id": "118703500",
+      "created": "2026-08-06T19:18:14Z",
+      "modified": "2026-08-06T19:18:14Z",
+      "title": "My Note",
+      "$t": "Note body text."
+    }
+  }
+}

--- a/tests/fixtures/tasks/notes/delete.json
+++ b/tests/fixtures/tasks/notes/delete.json
@@ -1,0 +1,6 @@
+{
+  "rsp": {
+    "stat": "ok",
+    "transaction": { "id": "12600000003", "undoable": "1" }
+  }
+}

--- a/tests/fixtures/tasks/notes/edit.json
+++ b/tests/fixtures/tasks/notes/edit.json
@@ -1,0 +1,13 @@
+{
+  "rsp": {
+    "stat": "ok",
+    "transaction": { "id": "12600000002", "undoable": "1" },
+    "note": {
+      "id": "118703500",
+      "created": "2026-08-06T19:18:14Z",
+      "modified": "2026-08-06T20:00:00Z",
+      "title": "Updated Note",
+      "$t": "Updated note body."
+    }
+  }
+}

--- a/tests/model/test_tasks.py
+++ b/tests/model/test_tasks.py
@@ -379,3 +379,165 @@ async def test_tasks_set_due_date(
     assert result.task_list.taskseries[0].id == 493137362
     assert result.task_list.taskseries[0].task[0].id == 924832826
     assert result.task_list.taskseries[0].task[0].due == due
+
+
+async def test_tasks_get_list_with_notes(
+    client: AioRTMClient,
+    mock_response: aiointercept,
+    generate_url: Callable[..., str],
+) -> None:
+    """Test tasks get list returns parsed notes."""
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.tasks.getList",
+        ),
+        body=load_fixture("tasks/get_list_with_notes.json"),
+    )
+
+    result = await client.rtm.tasks.get_list()
+
+    assert result.stat == "ok"
+    taskseries = result.tasks.task_list[0].taskseries[0]
+    assert len(taskseries.notes) == 2
+    assert taskseries.notes[0].id == 118703500
+    assert taskseries.notes[0].body == "Note 2."
+    assert taskseries.notes[0].title is None
+    assert taskseries.notes[1].id == 118701722
+    assert taskseries.notes[1].body == "Note 1."
+
+
+async def test_tasks_notes_add(
+    client: AioRTMClient,
+    mock_response: aiointercept,
+    timelines_create: str,
+    generate_url: Callable[..., str],
+) -> None:
+    """Test tasks notes add."""
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.timelines.create",
+        ),
+        body=timelines_create,
+    )
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.tasks.notes.add",
+            timeline=1234567890,
+            list_id=48730705,
+            taskseries_id=493137362,
+            task_id=924832826,
+            note_title="My Note",
+            note_text="Note body text.",
+        ),
+        body=load_fixture("tasks/notes/add.json"),
+    )
+
+    timeline_response = await client.rtm.timelines.create()
+    timeline = timeline_response.timeline
+    result = await client.rtm.tasks.notes.add(
+        timeline=timeline,
+        list_id=48730705,
+        taskseries_id=493137362,
+        task_id=924832826,
+        title="My Note",
+        text="Note body text.",
+    )
+
+    assert result.stat == "ok"
+    assert result.transaction.id == 12600000001
+    assert result.transaction.undoable == 1
+    assert result.note.id == 118703500
+    assert result.note.title == "My Note"
+    assert result.note.body == "Note body text."
+    assert result.note.created == datetime.fromisoformat("2026-08-06T19:18:14+00:00")
+    assert result.note.modified == datetime.fromisoformat("2026-08-06T19:18:14+00:00")
+
+
+async def test_tasks_notes_edit(
+    client: AioRTMClient,
+    mock_response: aiointercept,
+    timelines_create: str,
+    generate_url: Callable[..., str],
+) -> None:
+    """Test tasks notes edit."""
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.timelines.create",
+        ),
+        body=timelines_create,
+    )
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.tasks.notes.edit",
+            timeline=1234567890,
+            note_id=118703500,
+            note_title="Updated Note",
+            note_text="Updated note body.",
+        ),
+        body=load_fixture("tasks/notes/edit.json"),
+    )
+
+    timeline_response = await client.rtm.timelines.create()
+    timeline = timeline_response.timeline
+    result = await client.rtm.tasks.notes.edit(
+        timeline=timeline,
+        note_id=118703500,
+        title="Updated Note",
+        text="Updated note body.",
+    )
+
+    assert result.stat == "ok"
+    assert result.transaction.id == 12600000002
+    assert result.transaction.undoable == 1
+    assert result.note.id == 118703500
+    assert result.note.title == "Updated Note"
+    assert result.note.body == "Updated note body."
+    assert result.note.modified == datetime.fromisoformat("2026-08-06T20:00:00+00:00")
+
+
+async def test_tasks_notes_delete(
+    client: AioRTMClient,
+    mock_response: aiointercept,
+    timelines_create: str,
+    generate_url: Callable[..., str],
+) -> None:
+    """Test tasks notes delete."""
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.timelines.create",
+        ),
+        body=timelines_create,
+    )
+    mock_response.get(
+        generate_url(
+            api_key="test-api-key",
+            auth_token="test-token",
+            method="rtm.tasks.notes.delete",
+            timeline=1234567890,
+            note_id=118703500,
+        ),
+        body=load_fixture("tasks/notes/delete.json"),
+    )
+
+    timeline_response = await client.rtm.timelines.create()
+    timeline = timeline_response.timeline
+    result = await client.rtm.tasks.notes.delete(
+        timeline=timeline,
+        note_id=118703500,
+    )
+
+    assert result.stat == "ok"
+    assert result.transaction.id == 12600000003
+    assert result.transaction.undoable == 1


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiortm/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

- Adds a nested Notes model at client.rtm.tasks.notes, exposing notes.add, notes.edit, and notes.delete backed by the corresponding rtm.tasks.notes.* API methods
- Fixes TaskSeriesResponse.notes from list[str] to list[NoteResponse] with a __pre_deserialize__ that normalises RTM's {"note": [...]} form (populated tasks) to a plain list, consistent with the empty-list form. Confirmed against a real API response.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiortm/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If the lint job is failing, try `prek run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
